### PR TITLE
Revert "Use IndexSet"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,10 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-indexmap = "2.1.0"
 rustc-hash = "1.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
-pathfinding = "4.4.0"
 serde_json = "1.0"
 
 [[bench]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,8 @@ use std::cmp::Eq;
 use std::hash::Hash;
 use std::iter::FusedIterator;
 use std::usize;
-use std::hash::BuildHasherDefault;
 
-use indexmap::IndexSet;
-use rustc_hash::{FxHasher, FxHashMap  as HashMap};
-
-type FxIndexSet<T> = IndexSet<T, BuildHasherDefault<FxHasher>>;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// The Id refers to how a node or relationship is stored internally.
 // The Id is actually the index at which the node lives inside the `buf` array.
@@ -58,7 +54,7 @@ impl<'a, T: 'a + Eq + Hash + Clone> Data<T> {
     pub fn descendants_iter<'fc, Q: ?Sized + 'fc>(
         &self,
         nodes: impl IntoIterator<Item = &'fc Q>,
-    ) -> impl Iterator<Item = &T>
+    ) -> impl Iterator<Item = (usize, &T)>
     where
         T: Borrow<Q>,
         Q: Hash + Eq,
@@ -69,7 +65,7 @@ impl<'a, T: 'a + Eq + Hash + Clone> Data<T> {
             .flatten()
             .cloned()
             .collect();
-        LazyBFS::new(nodes, &self).map(|node_id| &self.id_label_map[&node_id])
+        LazyBFS::new(nodes, &self).map(|(level, node_id)| (level, &self.id_label_map[&node_id]))
     }
 }
 
@@ -129,21 +125,27 @@ impl<T: Eq + Hash + Clone> FromIterator<(T, T)> for Data<T> {
 }
 
 struct LazyBFS<'a, T: Eq + Hash + Clone> {
-    seen: FxIndexSet<NodeId>,
+    curr_level: Vec<NodeId>,
+    next_level: Vec<NodeId>,
+    visited_nodes: HashSet<NodeId>,
+    idx: usize, // index is always between 0 and `self.curr_level.len() - 1`
+    level: usize,
     data: &'a Data<T>, // needed for `get_children_as_ids` and `id_label_map`
-    idx: usize,
     children_idx: usize,
     children_idx_max: usize,
 }
 
 impl<'a, T: Eq + Hash + Clone> LazyBFS<'a, T> {
     fn new(start_nodes: Vec<NodeId>, data: &'a Data<T>) -> Self {
-        let seen = FxIndexSet::from_iter(start_nodes);
+        let visited_nodes = HashSet::from_iter(start_nodes.clone());
 
         Self {
-            seen,
-            data,
+            curr_level: start_nodes,
+            next_level: vec![],
+            visited_nodes,
             idx: 0,
+            level: 2, // level 1 contains `start_nodes`, its children are already level 2
+            data,
             children_idx: 0,
             children_idx_max: 0,
         }
@@ -152,13 +154,14 @@ impl<'a, T: Eq + Hash + Clone> LazyBFS<'a, T> {
 
 impl<T: Eq + Hash + Clone> LazyBFS<'_, T> {
     #[inline]
-    fn find_next_child(&mut self) -> Option<NodeId> {
+    fn find_next_child(&mut self) -> Option<(usize, NodeId)> {
         while self.children_idx != self.children_idx_max {
             let node_id = self.data.buf[self.children_idx];
             self.children_idx += 1;
 
-            if self.seen.insert(node_id) {
-                return Some(node_id);
+            if self.visited_nodes.insert(node_id) {
+                self.next_level.push(node_id);
+                return Some((self.level, node_id));
             }
         }
         None
@@ -166,7 +169,7 @@ impl<T: Eq + Hash + Clone> LazyBFS<'_, T> {
 }
 
 impl<T: Eq + Hash + Clone> Iterator for LazyBFS<'_, T> {
-    type Item = NodeId;
+    type Item = (usize, NodeId);
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -175,10 +178,24 @@ impl<T: Eq + Hash + Clone> Iterator for LazyBFS<'_, T> {
         }
 
         // find at least one child that we haven't seen before, and return that
-        while let Some(&node) = self.seen.get_index(self.idx) {
+        loop {
+            if self.idx >= self.curr_level.len() {
+                // if we're at the end of the current level and there is no next level; then we are finished.
+                if self.next_level.is_empty() {
+                    return None;
+                }
+
+                // self.curr_level = vec![];  // this vs `self.curr_level.clear()` ??
+                self.curr_level.clear();
+                std::mem::swap(&mut self.curr_level, &mut self.next_level);
+
+                self.level += 1;
+                self.idx = 0;
+            }
+
+            let node_id = usize::try_from(self.curr_level[self.idx]).unwrap();
             self.idx += 1;
 
-            let node_id = usize::try_from(node).unwrap();
             let n_children = usize::try_from(self.data.buf[node_id]).unwrap();
             if n_children != 0 {
                 let offset = node_id + 1;
@@ -190,37 +207,6 @@ impl<T: Eq + Hash + Clone> Iterator for LazyBFS<'_, T> {
                 }
             }
         }
-        return None
-
-        // loop {
-            // if self.idx >= self.curr_level.len() {
-            //     // if we're at the end of the current level and there is no next level; then we are finished.
-            //     if self.next_level.is_empty() {
-            //         return None;
-            //     }
-            //
-            //     // self.curr_level = vec![];  // this vs `self.curr_level.clear()` ??
-            //     self.curr_level.clear();
-            //     std::mem::swap(&mut self.curr_level, &mut self.next_level);
-            //
-            //     self.level += 1;
-            //     self.idx = 0;
-            // }
-
-            // let node_id = usize::try_from(self.curr_level[self.idx]).unwrap();
-            // self.idx += 1;
-            //
-            // let n_children = usize::try_from(self.data.buf[node_id]).unwrap();
-            // if n_children != 0 {
-            //     let offset = node_id + 1;
-            //     self.children_idx = offset;
-            //     self.children_idx_max = offset + n_children;
-            //
-            //     if let child @ Some(_) = self.find_next_child() {
-            //         return child;
-            //     }
-            // }
-        // }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
This reverts commit d93b2be7942a48daf621c5f691df0d3205baee34.

I wanted to give `indexmap` a try, but its surprisingly very slow (it seems like it needs to do 2 operations that are both O(1) to do a membership test. first compute the hash of the key, and from the hash it gets the index, which it uses to index the vector).

The benchmarks are slower by about 50%.

(this PR doesn't serve any purpose other than keeping track of the benchmark and the decision not to use `indexmap`)

```rust
$ cargo bench
   Compiling semver v1.0.20
   Compiling thiserror v1.0.50
   Compiling integer-sqrt v0.1.5
   Compiling fixedbitset v0.4.2
   Compiling thiserror-impl v1.0.50
   Compiling graph_traversal v0.0.0 (/home/shneor/Desktop/projects/rust/graph_traversal)
   Compiling deprecate-until v0.1.1
   Compiling pathfinding v4.4.0
^C  Building [=========================> ] 83/84: bench(bench)                                                                                  
shneor@shner:~/Desktop/projects/rust/graph_traversal$ ^C
shneor@shner:~/Desktop/projects/rust/graph_traversal$ cargo bench
   Compiling graph_traversal v0.0.0 (/home/shneor/Desktop/projects/rust/graph_traversal)
    Finished bench [optimized] target(s) in 3.23s
     Running unittests src/lib.rs (target/release/deps/graph_traversal-2acafb3e9e4d5949)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/bench.rs (target/release/deps/bench-7fd4e5e4d0e2d022)
get children            time:   [42.523 ns 42.561 ns 42.601 ns]
                        change: [-4.3013% -0.6657% +1.8611%] (p = 0.79 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

get children #2         time:   [35.913 ns 35.928 ns 35.945 ns]
                        change: [-4.6032% -3.9447% -3.4026%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

get children #3         time:   [12.617 ns 12.625 ns 12.632 ns]
                        change: [-8.4372% -8.2998% -8.1704%] (p = 0.00 < 0.05)
                        Performance has improved.

get children #4         time:   [7.2631 ns 7.2708 ns 7.2777 ns]
                        change: [-5.4222% -4.6589% -3.9455%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low severe
  5 (5.00%) low mild
  1 (1.00%) high mild

get children #5         time:   [13.546 ns 13.596 ns 13.642 ns]
                        change: [-9.0132% -4.7424% -1.1185%] (p = 0.02 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  12 (12.00%) high mild
  5 (5.00%) high severe

get children #6         time:   [13.521 ns 13.541 ns 13.572 ns]
                        change: [-4.0666% -2.1805% -0.5408%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking find descendants count: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.9s, or reduce sample count to 50.
find descendants count  time:   [89.442 ms 89.783 ms 90.144 ms]
                        change: [+50.110% +52.453% +54.697%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking find descendants count #2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.0s, or reduce sample count to 70.
find descendants count #2
                        time:   [69.118 ms 69.233 ms 69.354 ms]
                        change: [+41.581% +43.691% +45.747%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

find descendants count #3
                        time:   [811.48 µs 814.46 µs 817.89 µs]
                        change: [-2.2783% +5.3925% +13.265%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

find descendants count #4
                        time:   [724.00 ns 724.54 ns 725.04 ns]
                        change: [+24.225% +24.368% +24.490%] (p = 0.00 < 0.05)
                        Performance has regressed.

find descendants count #5
                        time:   [697.11 ns 697.45 ns 697.79 ns]
                        change: [+26.715% +26.898% +27.079%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

find descendants count #6
                        time:   [794.15 ns 794.56 ns 794.97 ns]
                        change: [+25.357% +25.649% +25.864%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking find descendants last: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.9s, or reduce sample count to 50.
find descendants last   time:   [89.107 ms 89.208 ms 89.313 ms]
                        change: [+59.649% +61.681% +63.441%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking find descendants last #2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.0s, or reduce sample count to 70.
find descendants last #2
                        time:   [69.275 ms 69.381 ms 69.493 ms]
                        change: [+47.241% +49.016% +50.399%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

find descendants last #3
                        time:   [819.33 µs 822.32 µs 825.60 µs]
                        change: [+37.795% +39.289% +40.712%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

find descendants last #4
                        time:   [685.39 ns 685.93 ns 686.46 ns]
                        change: [+18.807% +19.012% +19.202%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

find descendants last #5
                        time:   [666.48 ns 667.17 ns 667.90 ns]
                        change: [+22.023% +22.192% +22.351%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

find descendants last #6
                        time:   [758.76 ns 759.80 ns 761.06 ns]
                        change: [+22.519% +22.752% +22.982%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking find descendants to vec: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, or reduce sample count to 50.
find descendants to vec time:   [96.221 ms 96.331 ms 96.444 ms]
                        change: [+55.896% +56.797% +57.729%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking find descendants to vec #2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.5s, or reduce sample count to 60.
find descendants to vec #2
                        time:   [74.213 ms 74.285 ms 74.362 ms]
                        change: [+34.034% +35.083% +36.175%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

find descendants to vec #3
                        time:   [971.63 µs 985.59 µs 1.0088 ms]
                        change: [-6.5156% +0.1326% +6.5807%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

find descendants to vec #4
                        time:   [793.54 ns 794.83 ns 796.04 ns]
                        change: [-4.9479% -1.2198% +2.0749%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high mild

find descendants to vec #5
                        time:   [800.12 ns 801.30 ns 802.48 ns]
                        change: [+0.8967% +4.2572% +6.8976%] (p = 0.00 < 0.05)
                        Change within noise threshold.

find descendants to vec #6
                        time:   [967.27 ns 968.04 ns 968.85 ns]
                        change: [+5.1132% +10.021% +12.930%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

find descendants non-existent
                        time:   [25.199 ns 25.222 ns 25.247 ns]
                        change: [-36.306% -36.011% -35.719%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

find descendants non-existent #2
                        time:   [24.804 ns 24.835 ns 24.866 ns]
                        change: [-38.174% -38.116% -38.052%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

find descendants non-existent #3
                        time:   [25.085 ns 25.187 ns 25.287 ns]
                        change: [-34.386% -34.183% -33.979%] (p = 0.00 < 0.05)
                        Performance has improved.

find descendants non-existent #4
                        time:   [25.456 ns 25.496 ns 25.536 ns]
                        change: [-37.221% -37.141% -37.053%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

find descendants non-existent #5
                        time:   [26.161 ns 26.172 ns 26.183 ns]
                        change: [-36.772% -36.686% -36.605%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

find descendants non-existent #6
                        time:   [25.833 ns 25.849 ns 25.865 ns]
                        change: [-39.483% -39.147% -38.875%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild

find descendants non-existent #7
                        time:   [33.196 ns 33.227 ns 33.260 ns]
                        change: [-34.020% -33.826% -33.630%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

```